### PR TITLE
Custom loggers

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,30 +3,35 @@ import { freestyle, defaultBars } from './rap.js';
 /**
  * Default levels and logging methods.
  */
-const defaultLevels = {
+const defaultLevels = Object.freeze({
   none: 0,
   error: 1,
   warn: 2,
   info: 3,
   debug: 4,
   trace: 5,
-};
+});
 
 const originalConsole = { ...console };
-let logMethods = createDefaultLogMethods(defaultLevels);
+const defaultLoggers = createDefaultLogMethods(defaultLevels);
+let logMethods = { ...defaultLoggers };
 let levels = { ...defaultLevels };
-
 let currentLevel = detectLogLevel();
 
-/**
- * Detects the log level from the environment variable if running in Node.js.
- * Defaults to "none" if not set.
- */
-function detectLogLevel() {
-  const isNode = typeof process !== 'undefined' && process.env;
-  const envLevel = isNode ? process.env.LOG_LEVEL?.toLowerCase() : 'none';
-  return levels[envLevel] !== undefined ? levels[envLevel] : levels.none;
+// Export for ESM environments
+export { defaultLoggers, levels };
+
+// CommonJS compatibility check
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = {
+    defaultLoggers,
+    getCurrentLogLevel,
+    levels,
+    setLogLevel,
+    setLoggers,
+  };
 }
+
 
 /**
  * Sets the log level.
@@ -78,6 +83,16 @@ export function setLoggers(customLoggers) {
   levels = { ...customLevels };
   logMethods = createLogMethods(customLoggers);
   currentLevel = detectLogLevel(); // Reset log level after updating methods
+}
+
+/**
+ * Detects the log level from the environment variable if running in Node.js.
+ * Defaults to "none" if not set.
+ */
+function detectLogLevel() {
+  const isNode = typeof process !== 'undefined' && process.env;
+  const envLevel = isNode ? process.env.LOG_LEVEL?.toLowerCase() : 'none';
+  return levels[envLevel] !== undefined ? levels[envLevel] : levels.none;
 }
 
 /**
@@ -134,19 +149,3 @@ console.rap = () => {
     console.debug(bar);
   }
 };
-
-// Initialize default loggers on load
-logMethods = createDefaultLogMethods(defaultLevels);
-
-// Export for ESM environments
-export { levels };
-
-// CommonJS compatibility check
-if (typeof module !== 'undefined' && module.exports) {
-  module.exports = {
-    setLogLevel,
-    getCurrentLogLevel,
-    setLoggers,
-    levels,
-  };
-}

--- a/index.js
+++ b/index.js
@@ -1,49 +1,142 @@
 import { freestyle, defaultBars } from './rap.js';
 
-const levels = {
+/**
+ * Default levels and logging methods.
+ */
+const defaultLevels = {
   none: 0,
   error: 1,
-  info: 2,
-  debug: 3,
-  trace: 4,
+  warn: 2,
+  info: 3,
+  debug: 4,
+  trace: 5,
 };
 
-const isNode = typeof process !== 'undefined' && process.env;
-let currentLevel = levels[isNode ? process.env.LOG_LEVEL?.toLowerCase() : 'none'] || levels.none;
+const originalConsole = { ...console };
+let logMethods = createDefaultLogMethods(defaultLevels);
+let levels = { ...defaultLevels };
 
+let currentLevel = detectLogLevel();
+
+/**
+ * Detects the log level from the environment variable if running in Node.js.
+ * Defaults to "none" if not set.
+ */
+function detectLogLevel() {
+  const isNode = typeof process !== 'undefined' && process.env;
+  const envLevel = isNode ? process.env.LOG_LEVEL?.toLowerCase() : 'none';
+  return levels[envLevel] !== undefined ? levels[envLevel] : levels.none;
+}
+
+/**
+ * Sets the log level.
+ * @param {string} level - The desired log level.
+ */
+/**
+ * Sets the log level.
+ * @param {string} level - The desired log level.
+ */
 export function setLogLevel(level) {
+  const availableLevels = Object.keys(levels);
+
+  // Check if the provided level is valid
   if (typeof level === 'string' && levels[level.toLowerCase()] !== undefined) {
     currentLevel = levels[level.toLowerCase()];
+  } else if (currentLevel === 0) {
+    // If currentLevel is still at the default ("none"), fallback to the first available level
+    console.warn(`Invalid log level "${level}", defaulting to the first available level "${availableLevels[0]}"`);
+    currentLevel = levels[availableLevels[0]];
   } else {
-    console.warn(`Invalid log level "${level}", defaulting to "${Object.keys(levels)[currentLevel]}"`);
+    // If currentLevel is already set to a higher value, retain it
+    console.warn(`Invalid log level "${level}", retaining current level "${getCurrentLogLevel()}"`);
   }
 }
 
+/**
+ * Gets the current log level as a string.
+ * @returns {string} The current log level.
+ */
 export function getCurrentLogLevel() {
-  return Object.keys(levels).find(key => levels[key] === currentLevel);
+  return Object.keys(levels).find((key) => levels[key] === currentLevel);
 }
 
-const originalConsole = { ...console };
+/**
+ * Allows the user to set custom loggers.
+ * @param {Array} customLoggers - An array of custom logging functions.
+ */
+export function setLoggers(customLoggers) {
+  const customLevels = customLoggers.reduce((acc, method, index) => {
+    if (typeof method === 'function' && method.name) {
+      acc[method.name.toLowerCase()] = index;
+    } else {
+      throw new Error('All logging methods must be named functions');
+    }
+    return acc;
+  }, {});
 
-console.info = (message, ...args) => {
-  if (currentLevel >= levels.info) originalConsole.log(`INFO - ${message}`, ...args);
-};
-console.error = (message, ...args) => {
-  if (currentLevel >= levels.error) originalConsole.error(`ERROR - ${message}`, ...args);
-};
-console.debug = (message, ...args) => {
-  if (currentLevel >= levels.debug) originalConsole.debug(`DEBUG - ${message}`, ...args);
-};
-console.trace = (message, ...args) => {
-  if (currentLevel >= levels.trace) originalConsole.trace(`TRACE - ${message}`, ...args);
-};
+  // Update levels and log methods based on custom loggers
+  levels = { ...customLevels };
+  logMethods = createLogMethods(customLoggers);
+  currentLevel = detectLogLevel(); // Reset log level after updating methods
+}
 
+/**
+ * Creates the default log methods based on predefined levels.
+ * @param {Object} levels - An object defining log levels.
+ * @returns {Object} Log methods respecting the current level.
+ */
+function createDefaultLogMethods(levels) {
+  return {
+    none: (message, ...args) => originalConsole.log(message, ...args),
+    error: (message, ...args) => {
+      if (currentLevel >= levels.error) originalConsole.error(`ERROR - ${message}`, ...args);
+    },
+    warn: (message, ...args) => {
+      if (currentLevel >= levels.warn) originalConsole.warn(`WARN - ${message}`, ...args);
+    },
+    info: (message, ...args) => {
+      if (currentLevel >= levels.info) originalConsole.info(`INFO - ${message}`, ...args);
+    },
+    debug: (message, ...args) => {
+      if (currentLevel >= levels.debug) originalConsole.debug(`DEBUG - ${message}`, ...args);
+    },
+    trace: (message, ...args) => {
+      if (currentLevel >= levels.trace) originalConsole.trace(`TRACE - ${message}`, ...args);
+    },
+  };
+}
+
+/**
+ * Creates custom log methods based on the provided functions.
+ * @param {Array} loggerArray - An array of logging functions.
+ * @returns {Object} Log methods respecting the current level.
+ */
+function createLogMethods(loggerArray) {
+  return loggerArray.reduce((acc, method, index) => {
+    acc[method.name.toLowerCase()] = (...args) => {
+      if (index <= currentLevel) method(...args);
+    };
+    return acc;
+  }, {});
+}
+
+/**
+ * A default "none" log level function.
+ */
+function none(...args) {
+  console.log(...args);
+}
+
+// Example usage of the freestyle rap function
 console.rap = () => {
   const bars = freestyle(defaultBars);
   for (const bar of bars) {
     console.debug(bar);
   }
 };
+
+// Initialize default loggers on load
+logMethods = createDefaultLogMethods(defaultLevels);
 
 // Export for ESM environments
 export { levels };
@@ -53,6 +146,7 @@ if (typeof module !== 'undefined' && module.exports) {
   module.exports = {
     setLogLevel,
     getCurrentLogLevel,
+    setLoggers,
     levels,
   };
 }

--- a/test.js
+++ b/test.js
@@ -1,4 +1,4 @@
-import { getCurrentLogLevel, setLogLevel, setLoggers } from './index.js';
+import { defaultLoggers, getCurrentLogLevel, setLogLevel, setLoggers } from './index.js';
 
 const levels = [
   'none',
@@ -114,6 +114,25 @@ for (let i = 0; i < customLevels.length; i++) {
 console.log('\n===================');
 console.log('TEST SUMMARY');
 console.log('===================');
+
+setLoggers(defaultLoggers);
+
+printSectionHeader('Test each level logging');
+for (let i = 0; i < levels.length; i++) {
+  const level = levels[i];
+  const msg = `should log ${i} time${i === 1 ? '' : 's'}`;
+  setLogLevel(level);
+  console.log(`\nCurrent level: "${getCurrentLogLevel()}"`);
+
+  // Log messages based on level
+  console.error(`ERROR: ${msg}`); // Should log at "error" and above
+  console.info(`INFO: ${msg}`);   // Should log at "info" and above
+  console.debug(`DEBUG: ${msg}`);  // Should log at "debug" and above
+  console.trace(`TRACE: ${msg}`);  // Should log at "trace" level only
+
+  // Assert that getCurrentLogLevel matches the set level
+  assert(getCurrentLogLevel() === level, `Current level should be "${level}"`);
+}
 
 if (hasFailures) {
   console.error('❌ Some tests failed.');

--- a/test.js
+++ b/test.js
@@ -8,6 +8,7 @@ let hasFailures = false;
 // Custom Loggers Mimicking Chrome Behavior
 const customLoggers = [
   function none(...args) { console.log('[NONE]', ...args); },
+  function critical(...args) { console.error('[CRITICAL]', ...args); },
   function error(...args) { console.error('[ERROR]', ...args); },
   function warn(...args) { console.warn('[WARN]', ...args); },
   function info(...args) { console.info('[INFO]', ...args); },
@@ -15,24 +16,29 @@ const customLoggers = [
   function trace(...args) { console.debug('[TRACE-DEBUG-KICK-IT-CHROME]', ...args); },
 ];
 
-runTests(customLoggers);
+runTests();
 
 // Run Tests
-function runTests(customLoggers) {
-  printSectionHeader('RUNNING TEST SUITE');
-  testDefaultLevels();
-  testCustomLoggers(customLoggers);
-  resetToDefaultLoggers();
+function runTests() {
+  try {
+    printSectionHeader('RUNNING TEST SUITE');
+    testDefaultLevels();
+    testCustomLoggers();
+    resetToDefaultLoggers();
 
-  // Test Summary
-  console.log('\n===================');
-  console.log('TEST SUMMARY');
-  console.log('===================');
-  if (hasFailures) {
-    console.error('❌ Some tests failed.');
+    // Test Summary
+    console.log('\n===================');
+    console.log('TEST SUMMARY');
+    console.log('===================');
+    if (hasFailures) {
+      console.error('❌ Some tests failed.');
+      process.exit(1);
+    } else {
+      console.log('✅ All tests passed.');
+    }
+  } catch (error) {
+    console.error('❌ A fatal error occurred during testing:', error);
     process.exit(1);
-  } else {
-    console.log('✅ All tests passed.');
   }
 }
 
@@ -41,7 +47,7 @@ function assert(condition, message) {
   if (condition) {
     console.log(`✅ PASS: ${message}`);
   } else {
-    console.error(`❌ FAIL: ${message}`);
+    console.log(`❌ FAIL: ${message}`);
     hasFailures = true;
   }
 }
@@ -83,7 +89,7 @@ function testDefaultLevels() {
 }
 
 // Test Custom Loggers
-function testCustomLoggers(customLoggers) {
+function testCustomLoggers() {
   printSectionHeader('Custom Loggers Setup');
   setLoggers(customLoggers);
 

--- a/test.js
+++ b/test.js
@@ -1,4 +1,4 @@
-import { getCurrentLogLevel, setLogLevel } from './index.js';
+import { getCurrentLogLevel, setLogLevel, setLoggers } from './index.js';
 
 const levels = [
   'none',
@@ -59,6 +59,55 @@ for (let i = 0; i < levels.length; i++) {
 
   // Assert that getCurrentLogLevel matches the set level
   assert(getCurrentLogLevel() === level, `Current level should be "${level}"`);
+}
+
+// Define custom loggers mimicking Chrome behavior
+const customLoggers = [
+  function none(...args) { console.log('[NONE]', ...args); },
+  function error(...args) { console.error('[ERROR]', ...args); },
+  function warn(...args) { console.warn('[WARN]', ...args); },
+  function info(...args) { console.info('[INFO]', ...args); },
+  function debug(...args) { console.debug('[DEBUG]', ...args); },
+  function trace(...args) { console.debug('[TRACE-DEBUG-KICK-IT-CHROME]', ...args); },
+];
+
+// Set custom loggers and run tests
+printSectionHeader('Test custom loggers setup');
+setLoggers(customLoggers);
+
+assert(getCurrentLogLevel() === 'none', 'Default log level should be "none" after setting custom loggers');
+console.log(`Current level: ${getCurrentLogLevel()}`);
+
+// Test invalid and falsy values
+printSectionHeader('Test invalid log level');
+setLogLevel('foobar');
+assert(getCurrentLogLevel() === 'none', 'Invalid log level should retain "none" level');
+console.log(`Current level after invalid input: ${getCurrentLogLevel()}`);
+
+printSectionHeader('Test falsey value for setLogLevel');
+setLogLevel(undefined);
+assert(getCurrentLogLevel() === 'none', 'Setting log level to undefined should retain "none" level');
+console.log(`Current level after falsey input: ${getCurrentLogLevel()}`);
+
+// Test setting each level with custom loggers
+const customLevels = ['none', 'error', 'warn', 'info', 'debug', 'trace'];
+
+for (let i = 0; i < customLevels.length; i++) {
+  const level = customLevels[i];
+  const msg = `should log at level "${level}"`;
+
+  printSectionHeader(`Set log level to "${level}"`);
+  setLogLevel(level);
+  assert(getCurrentLogLevel() === level, `Log level should be set to "${level}"`);
+
+  // Log messages based on level
+  console.error(`[ERROR] ${msg}`); // Should log at "error" and above
+  console.warn(`[WARN] ${msg}`);   // Should log at "warn" and above
+  console.info(`[INFO] ${msg}`);   // Should log at "info" and above
+  console.trace(`[TRACE] ${msg}`); // Should log at "trace" level and above
+  console.debug(`[DEBUG] ${msg}`); // Should log at "debug" level only
+
+  console.log(`\nCurrent level: "${getCurrentLogLevel()}"`);
 }
 
 // Summary of test results

--- a/test.js
+++ b/test.js
@@ -1,67 +1,11 @@
 import { defaultLoggers, getCurrentLogLevel, setLogLevel, setLoggers } from './index.js';
 
-const levels = [
-  'none',
-  'error',
-  'info',
-  'debug',
-  'trace',
-];
+const defaultLevels = ['none', 'error', 'info', 'debug', 'trace'];
+const customLevels = ['none', 'error', 'warn', 'info', 'debug', 'trace'];
 
 let hasFailures = false;
 
-// Basic assertion function to display clear pass/fail messages
-function assert(condition, message) {
-  if (condition) {
-    console.log(`✅ PASS: ${message}`);
-  } else {
-    console.error(`❌ FAIL: ${message}`);
-    hasFailures = true; // Mark that there was a failure
-  }
-}
-
-// Helper to print a section header
-function printSectionHeader(title) {
-  console.log(`\n=== ${title.toUpperCase()} ===`);
-}
-
-printSectionHeader('Test default level');
-assert(getCurrentLogLevel() === 'none', 'Default log level should be "none"');
-console.log(`Current level: ${getCurrentLogLevel()}`);
-
-printSectionHeader('Test falsey values for setLogLevel');
-setLogLevel(undefined);
-assert(getCurrentLogLevel() === 'none', 'Setting log level to undefined should retain "none" level');
-console.log(`Current level: ${getCurrentLogLevel()}`);
-
-printSectionHeader('Test invalid value for setLogLevel');
-setLogLevel('foobar');
-assert(getCurrentLogLevel() === 'none', 'Setting log level to invalid value should retain "none" level');
-console.log(`Current level: ${getCurrentLogLevel()}`);
-
-printSectionHeader('Test uppercase input for setLogLevel');
-setLogLevel('DEBUG');
-assert(getCurrentLogLevel() === 'debug', 'Setting log level to "DEBUG" (uppercase) should set to "debug"');
-console.log(`Current level: ${getCurrentLogLevel()}`);
-
-printSectionHeader('Test each level logging');
-for (let i = 0; i < levels.length; i++) {
-  const level = levels[i];
-  const msg = `should log ${i} time${i === 1 ? '' : 's'}`;
-  setLogLevel(level);
-  console.log(`\nCurrent level: "${getCurrentLogLevel()}"`);
-
-  // Log messages based on level
-  console.error(`ERROR: ${msg}`); // Should log at "error" and above
-  console.info(`INFO: ${msg}`);   // Should log at "info" and above
-  console.debug(`DEBUG: ${msg}`);  // Should log at "debug" and above
-  console.trace(`TRACE: ${msg}`);  // Should log at "trace" level only
-
-  // Assert that getCurrentLogLevel matches the set level
-  assert(getCurrentLogLevel() === level, `Current level should be "${level}"`);
-}
-
-// Define custom loggers mimicking Chrome behavior
+// Custom Loggers Mimicking Chrome Behavior
 const customLoggers = [
   function none(...args) { console.log('[NONE]', ...args); },
   function error(...args) { console.error('[ERROR]', ...args); },
@@ -71,72 +15,94 @@ const customLoggers = [
   function trace(...args) { console.debug('[TRACE-DEBUG-KICK-IT-CHROME]', ...args); },
 ];
 
-// Set custom loggers and run tests
-printSectionHeader('Test custom loggers setup');
-setLoggers(customLoggers);
+runTests(customLoggers);
 
-assert(getCurrentLogLevel() === 'none', 'Default log level should be "none" after setting custom loggers');
-console.log(`Current level: ${getCurrentLogLevel()}`);
+// Run Tests
+function runTests(customLoggers) {
+  printSectionHeader('RUNNING TEST SUITE');
+  testDefaultLevels();
+  testCustomLoggers(customLoggers);
+  resetToDefaultLoggers();
 
-// Test invalid and falsy values
-printSectionHeader('Test invalid log level');
-setLogLevel('foobar');
-assert(getCurrentLogLevel() === 'none', 'Invalid log level should retain "none" level');
-console.log(`Current level after invalid input: ${getCurrentLogLevel()}`);
+  // Test Summary
+  console.log('\n===================');
+  console.log('TEST SUMMARY');
+  console.log('===================');
+  if (hasFailures) {
+    console.error('❌ Some tests failed.');
+    process.exit(1);
+  } else {
+    console.log('✅ All tests passed.');
+  }
+}
 
-printSectionHeader('Test falsey value for setLogLevel');
-setLogLevel(undefined);
-assert(getCurrentLogLevel() === 'none', 'Setting log level to undefined should retain "none" level');
-console.log(`Current level after falsey input: ${getCurrentLogLevel()}`);
+// Assertion Function
+function assert(condition, message) {
+  if (condition) {
+    console.log(`✅ PASS: ${message}`);
+  } else {
+    console.error(`❌ FAIL: ${message}`);
+    hasFailures = true;
+  }
+}
 
-// Test setting each level with custom loggers
-const customLevels = ['none', 'error', 'warn', 'info', 'debug', 'trace'];
+// Helper Functions
+function printSectionHeader(title) {
+  console.log(`\n=== ${title.toUpperCase()} ===`);
+}
 
-for (let i = 0; i < customLevels.length; i++) {
-  const level = customLevels[i];
+function testLogLevel(level, expected) {
+  setLogLevel(level);
+  const currentLevel = getCurrentLogLevel();
+  assert(currentLevel === expected, `Log level should be set to "${expected}"`);
+  console.log(`Current level: ${currentLevel}`);
+}
+
+function testLoggingMessages(level) {
   const msg = `should log at level "${level}"`;
-
-  printSectionHeader(`Set log level to "${level}"`);
-  setLogLevel(level);
-  assert(getCurrentLogLevel() === level, `Log level should be set to "${level}"`);
-
-  // Log messages based on level
-  console.error(`[ERROR] ${msg}`); // Should log at "error" and above
-  console.warn(`[WARN] ${msg}`);   // Should log at "warn" and above
-  console.info(`[INFO] ${msg}`);   // Should log at "info" and above
-  console.trace(`[TRACE] ${msg}`); // Should log at "trace" level and above
-  console.debug(`[DEBUG] ${msg}`); // Should log at "debug" level only
-
-  console.log(`\nCurrent level: "${getCurrentLogLevel()}"`);
+  console.error(`[ERROR] ${msg}`);
+  console.warn(`[WARN] ${msg}`);
+  console.info(`[INFO] ${msg}`);
+  console.debug(`[DEBUG] ${msg}`);
+  console.trace(`[TRACE] ${msg}`);
 }
 
-// Summary of test results
-console.log('\n===================');
-console.log('TEST SUMMARY');
-console.log('===================');
+// Test Default Log Levels
+function testDefaultLevels() {
+  printSectionHeader('Default Log Levels');
+  
+  testLogLevel(undefined, 'none');
+  testLogLevel('foobar', 'none');
+  testLogLevel('DEBUG', 'debug');
 
-setLoggers(defaultLoggers);
-
-printSectionHeader('Test each level logging');
-for (let i = 0; i < levels.length; i++) {
-  const level = levels[i];
-  const msg = `should log ${i} time${i === 1 ? '' : 's'}`;
-  setLogLevel(level);
-  console.log(`\nCurrent level: "${getCurrentLogLevel()}"`);
-
-  // Log messages based on level
-  console.error(`ERROR: ${msg}`); // Should log at "error" and above
-  console.info(`INFO: ${msg}`);   // Should log at "info" and above
-  console.debug(`DEBUG: ${msg}`);  // Should log at "debug" and above
-  console.trace(`TRACE: ${msg}`);  // Should log at "trace" level only
-
-  // Assert that getCurrentLogLevel matches the set level
-  assert(getCurrentLogLevel() === level, `Current level should be "${level}"`);
+  printSectionHeader('Test each default level logging');
+  defaultLevels.forEach((level) => {
+    testLogLevel(level, level);
+    testLoggingMessages(level);
+  });
 }
 
-if (hasFailures) {
-  console.error('❌ Some tests failed.');
-  process.exit(1);
-} else {
-  console.log('✅ All tests passed.');
+// Test Custom Loggers
+function testCustomLoggers(customLoggers) {
+  printSectionHeader('Custom Loggers Setup');
+  setLoggers(customLoggers);
+
+  testLogLevel('foobar', 'none');
+  testLogLevel(undefined, 'none');
+
+  printSectionHeader('Test each custom level logging');
+  customLevels.forEach((level) => {
+    testLogLevel(level, level);
+    testLoggingMessages(level);
+  });
+}
+
+// Reset to Default Loggers
+function resetToDefaultLoggers() {
+  setLoggers(defaultLoggers);
+  printSectionHeader('Reset to Default Loggers');
+  defaultLevels.forEach((level) => {
+    testLogLevel(level, level);
+    testLoggingMessages(level);
+  });
 }


### PR DESCRIPTION
The use case: Chrome dev tools uintuitatvely treats `trace` as more important than `debug` and requires you to set the Verbose setting in the [filter setting](https://developer.chrome.com/docs/devtools/console/reference#level) to see them.

This PR allows a user to provide custom loggers so they can define their own log order, method, and formatting.

## TODO

- [ ] Make logs show the original line of the long in the console
- [ ] Assert formatting in tests
- [ ] Remove unnecessary logs in tests
- [ ] Update readme